### PR TITLE
added bootstrap option to inspector and session

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const { isBare } = require('which-runtime')
 const VERSION = 2
 
 class Inspector {
-  constructor ({ dhtServer, inspectorKey, inspector, filename } = {}) {
+  constructor ({ dhtServer, inspectorKey, inspector, filename, bootstrap } = {}) {
     if (dhtServer && inspectorKey) throw new Error('Inspector constructor cannot take both dhtServer and inspectorKey')
     if (!inspector) {
       try {
@@ -25,6 +25,7 @@ class Inspector {
     this.dhtServerHandledExternally = !!dhtServer
     this.stopping = false
     this.oldGlobalConsole = null
+    this.bootstrap = bootstrap
   }
 
   _overrideGlobalConsole () {
@@ -67,7 +68,7 @@ class Inspector {
     }
 
     if (shouldCreateServer) {
-      this.dht = new HyperDht()
+      this.dht = new HyperDht({ bootstrap: this.bootstrap })
       this.dhtServer = this.dht.createServer({
         firewall (remotePublicKey, remote) {
           return !b4a.equals(remotePublicKey, this.publicKey)
@@ -171,7 +172,7 @@ class Inspector {
 }
 
 class Session extends EventEmitter {
-  constructor ({ inspectorKey, publicKey }) {
+  constructor ({ inspectorKey, publicKey, bootstrap }) {
     super()
 
     const hasCorrectParams = (inspectorKey && !publicKey) || (!inspectorKey && publicKey)
@@ -179,7 +180,7 @@ class Session extends EventEmitter {
 
     let hasReceivedHandshake = false
     this.connected = false
-    this.dhtClient = new HyperDht()
+    this.dhtClient = new HyperDht({ bootstrap })
     this.dhtSocket = null
     if (inspectorKey) {
       const keyPair = HyperDht.keyPair(inspectorKey)

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class Inspector {
     this.dhtServerHandledExternally = !!dhtServer
     this.stopping = false
     this.oldGlobalConsole = null
-    this.bootstrap = bootstrap
+    this.bootstrap = global.Pear?.config?.dht?.bootstrap || bootstrap
   }
 
   _overrideGlobalConsole () {
@@ -172,7 +172,7 @@ class Inspector {
 }
 
 class Session extends EventEmitter {
-  constructor ({ inspectorKey, publicKey, bootstrap }) {
+  constructor ({ inspectorKey, publicKey, bootstrap = global.Pear?.config?.dht?.bootstrap }) {
     super()
 
     const hasCorrectParams = (inspectorKey && !publicKey) || (!inspectorKey && publicKey)
@@ -180,6 +180,7 @@ class Session extends EventEmitter {
 
     let hasReceivedHandshake = false
     this.connected = false
+    this.bootstrap = bootstrap
     this.dhtClient = new HyperDht({ bootstrap })
     this.dhtSocket = null
     if (inspectorKey) {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "which-runtime": "^1.2.0"
   },
   "devDependencies": {
+    "@hyperswarm/testnet": "^3.1.4",
     "brittle": "^3.3.2",
     "standard": "^17.1.0"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@ const { Inspector, Session } = require('../')
 const HyperDht = require('hyperdht')
 const nodeInspector = require('inspector')
 const { spawn } = require('child_process')
+const createTestnet = require('@hyperswarm/testnet')
 
 let inspector
 let session
@@ -12,13 +13,21 @@ async function teardown () {
   await session?.destroy()
 }
 
+async function setupTestnet (t) {
+  const testnet = await createTestnet(10)
+  t.teardown(() => testnet.destroy())
+  return testnet.bootstrap
+}
+
 test('Inspector evaluates correctly', async t => {
   t.teardown(teardown)
   t.plan(5)
-  inspector = new Inspector({ inspector: nodeInspector })
+
+  const bootstrap = await setupTestnet(t)
+  inspector = new Inspector({ inspector: nodeInspector, bootstrap })
   const inspectorKey = await inspector.enable()
 
-  session = new Session({ inspectorKey })
+  session = new Session({ inspectorKey, bootstrap })
   session.once('message', ({ id, result, error }) => {
     const { result: { type, value, description } } = result
     t.is(id, 1)
@@ -40,10 +49,11 @@ test('Message with errornous code returns error', async t => {
   t.teardown(teardown)
   t.plan(3)
 
-  inspector = new Inspector({ inspector: nodeInspector })
+  const bootstrap = await setupTestnet(t)
+  inspector = new Inspector({ inspector: nodeInspector, bootstrap })
   const inspectorKey = await inspector.enable()
 
-  session = new Session({ inspectorKey })
+  session = new Session({ inspectorKey, bootstrap })
   session.once('message', ({ id, result, error }) => {
     t.is(id, 1)
     t.absent(result)
@@ -61,10 +71,11 @@ test('Message with no return value, returns message with empty object', async t 
   t.teardown(teardown)
   t.plan(1)
 
-  inspector = new Inspector({ inspector: nodeInspector })
+  const bootstrap = await setupTestnet(t)
+  inspector = new Inspector({ inspector: nodeInspector, bootstrap })
   const inspectorKey = await inspector.enable()
 
-  session = new Session({ inspectorKey })
+  session = new Session({ inspectorKey, bootstrap })
   session.on('message', ({ result }) => {
     t.is(Object.keys(result).length, 0)
   })
@@ -79,10 +90,12 @@ test('Several calls with different return values to ensure order works', async t
   t.teardown(teardown)
   t.plan(10)
 
-  inspector = new Inspector({ inspector: nodeInspector })
+  const bootstrap = await setupTestnet(t)
+
+  inspector = new Inspector({ inspector: nodeInspector, bootstrap })
   const inspectorKey = await inspector.enable()
 
-  session = new Session({ inspectorKey })
+  session = new Session({ inspectorKey, bootstrap })
   session.on('message', ({ id, result }) => {
     const { result: { value } } = result
     t.is(id, value)
@@ -104,10 +117,12 @@ test('Enabling console allows to read logs', async t => {
   t.teardown(teardown)
   t.plan(4)
 
-  inspector = new Inspector({ inspector: nodeInspector })
+  const bootstrap = await setupTestnet(t)
+
+  inspector = new Inspector({ inspector: nodeInspector, bootstrap })
   const inspectorKey = await inspector.enable()
 
-  session = new Session({ inspectorKey })
+  session = new Session({ inspectorKey, bootstrap })
   session.connect()
 
   session.once('message', ({ id, result }) => {
@@ -149,15 +164,17 @@ test('inspector is optional', t => {
 test('Use own hypderdht server for Inspector', async t => {
   t.plan(3)
 
+  const bootstrap = await setupTestnet(t)
+
   const keyPair = HyperDht.keyPair()
-  const dht = new HyperDht()
+  const dht = new HyperDht({ bootstrap })
   const dhtServer = dht.createServer()
   await dhtServer.listen(keyPair)
   const inspector = new Inspector({ dhtServer, inspector: nodeInspector })
   const inspectorKey = await inspector.enable()
   t.absent(inspectorKey) // keys aren't returned when handled by self
 
-  session = new Session({ publicKey: keyPair.publicKey })
+  session = new Session({ publicKey: keyPair.publicKey, bootstrap })
   session.once('message', async ({ id, result }) => {
     t.is(id, 1)
     t.is(result.result.value, 3)
@@ -175,11 +192,12 @@ test('Use own inspectorKey', async t => {
   t.teardown(teardown)
   t.plan(2)
 
+  const bootstrap = await setupTestnet(t)
   const inspectorKey = HyperDht.keyPair().secretKey.subarray(0, 32)
-  inspector = new Inspector({ inspectorKey, inspector: nodeInspector })
+  inspector = new Inspector({ inspectorKey, inspector: nodeInspector, bootstrap })
   await inspector.enable()
 
-  session = new Session({ inspectorKey })
+  session = new Session({ inspectorKey, bootstrap })
   session.once('message', async ({ id, result }) => {
     t.is(id, 1)
     t.is(result.result.value, 3)
@@ -193,10 +211,11 @@ test('Get messages from the Inspector that was not sent by the Session', async t
   t.teardown(teardown)
   t.plan(3)
 
-  inspector = new Inspector({ inspector: nodeInspector })
+  const bootstrap = await setupTestnet(t)
+  inspector = new Inspector({ inspector: nodeInspector, bootstrap })
   const inspectorKey = await inspector.enable()
 
-  session = new Session({ inspectorKey })
+  session = new Session({ inspectorKey, bootstrap })
   session.once('message', async ({ id, method, params }) => {
     // `Runtime.executionContextCreated` happens as a side effect to calling `Runtime.enable`, but is not a direct response (i.e. `id` is not set)
     t.is(method, 'Runtime.executionContextCreated')
@@ -217,10 +236,11 @@ test('Creating session, emits an info event', async t => {
   t.teardown(teardown)
   t.plan(1)
 
-  inspector = new Inspector({ inspector: nodeInspector })
+  const bootstrap = await setupTestnet(t)
+  inspector = new Inspector({ inspector: nodeInspector, bootstrap })
   const inspectorKey = await inspector.enable()
 
-  session = new Session({ inspectorKey })
+  session = new Session({ inspectorKey, bootstrap })
   session.on('info', ({ filename }) => {
     t.ok(filename.endsWith('pear-inspect/test/test.js'))
   })
@@ -230,11 +250,12 @@ test('Calling .post(), ensure that "info" is emitted, then "message"', async t =
   t.teardown(teardown)
   t.plan(2)
 
-  inspector = new Inspector({ inspector: nodeInspector })
+  const bootstrap = await setupTestnet(t)
+  inspector = new Inspector({ inspector: nodeInspector, bootstrap })
   const inspectorKey = await inspector.enable()
 
   let calls = 0
-  session = new Session({ inspectorKey })
+  session = new Session({ inspectorKey, bootstrap })
   session.on('info', () => {
     calls += 1
     t.is(calls, 1)
@@ -255,10 +276,11 @@ test('Calling .post() before .connect() throws', async t => {
   t.teardown(teardown)
   t.plan(1)
 
-  inspector = new Inspector({ inspector: nodeInspector })
+  const bootstrap = await setupTestnet(t)
+  inspector = new Inspector({ inspector: nodeInspector, bootstrap })
   const inspectorKey = await inspector.enable()
 
-  session = new Session({ inspectorKey })
+  session = new Session({ inspectorKey, bootstrap })
 
   t.exception(() => {
     session.post({
@@ -273,10 +295,11 @@ test('.post() after a .disconnect() throws', async t => {
   t.teardown(teardown)
   t.plan(2)
 
-  inspector = new Inspector({ inspector: nodeInspector })
+  const bootstrap = await setupTestnet(t)
+  inspector = new Inspector({ inspector: nodeInspector, bootstrap })
   const inspectorKey = await inspector.enable()
 
-  session = new Session({ inspectorKey })
+  session = new Session({ inspectorKey, bootstrap })
   session.on('message', () => t.pass())
 
   session.connect()
@@ -299,10 +322,11 @@ test('Calling .connect() after a .disconnect() still allows .post()', async t =>
   t.teardown(teardown)
   t.plan(2)
 
-  inspector = new Inspector({ inspector: nodeInspector })
+  const bootstrap = await setupTestnet(t)
+  inspector = new Inspector({ inspector: nodeInspector, bootstrap })
   const inspectorKey = await inspector.enable()
 
-  session = new Session({ inspectorKey })
+  session = new Session({ inspectorKey, bootstrap })
   session.on('message', () => t.pass())
 
   session.connect()
@@ -326,10 +350,11 @@ test('Setting filename overrides the default on', async t => {
   t.teardown(teardown)
   t.plan(1)
 
-  inspector = new Inspector({ inspector: nodeInspector, filename: 'foobar.js' })
+  const bootstrap = await setupTestnet(t)
+  inspector = new Inspector({ inspector: nodeInspector, filename: 'foobar.js', bootstrap })
   const inspectorKey = await inspector.enable()
 
-  session = new Session({ inspectorKey })
+  session = new Session({ inspectorKey, bootstrap })
   session.on('info', ({ filename }) => {
     t.is(filename, 'foobar.js')
   })

--- a/test/test.js
+++ b/test/test.js
@@ -399,3 +399,17 @@ test.skip('Filename is set for Pear', async t => {
     t.ok(filename.endsWith('/test/fixtures/pear-project/index.js'))
   })
 })
+
+test('Uses global Pear bootstrap', async t => {
+  t.teardown(teardown)
+  t.plan(2)
+
+  global.Pear = { config: { dht: {} } }
+  global.Pear.config.dht.bootstrap = await setupTestnet(t)
+  inspector = new Inspector({ inspector: nodeInspector })
+  const inspectorKey = await inspector.enable()
+  session = new Session({ inspectorKey })
+
+  t.is(inspector.bootstrap.toString(), global.Pear.config.dht.bootstrap.toString())
+  t.is(session.bootstrap.toString(), global.Pear.config.dht.bootstrap.toString())
+})


### PR DESCRIPTION
This PR adds DHT bootstrap support and changes tests to use a local testnet instead of production DHT.